### PR TITLE
Regression: fix allowing to use variables in variables

### DIFF
--- a/repex.py
+++ b/repex.py
@@ -256,6 +256,17 @@ class _VariablesHandler(object):
 
         unexpanded_instances = set()
 
+        # Expand variables in variables
+        # TODO: This should be done in the global scope.
+        # _VariableHandler is called per path, which makes this redundant
+        # as variables are declared globally per config.
+        for k, v in repex_vars.items():
+            repex_vars[k] = self._expand_var(v, repex_vars)
+            instances = self._get_instances(repex_vars[k])
+            unexpanded_instances.update(instances)
+
+        # TODO: Consolidate variable expansion code into single logic
+        # Expand variables in path objects
         for key in fields.keys():
             field = fields[key]
             if isinstance(field, str):

--- a/tests/resources/mock_multiple_files.yaml
+++ b/tests/resources/mock_multiple_files.yaml
@@ -1,3 +1,7 @@
+variables:
+    # This also tests that variables are expanded
+    dversion: "{{ .version }}"
+
 paths:
     -   type: mock_VERSION
         path: multipl(e)?
@@ -6,7 +10,7 @@ paths:
         base_directory: tests/resources/
         match: '"version": "\d+\.\d+(\.\d+)?(-\w\d+)?'
         replace: \d+\.\d+(\.\d+)?(-\w\d+)?
-        with: "{{ .version }}"
+        with: "{{ .dversion }}"
         must_include:
             - date
             - commit

--- a/tests/test_repex.py
+++ b/tests/test_repex.py
@@ -128,6 +128,9 @@ class TestIterate():
                                in self.version_files_without_excluded]
 
     def test_iterate_multiple_files(self):
+        # Note that this also tests expanding variables in variables
+        # as the variable declared in the `mock_multiple_files.yaml`
+        # is being expanded itself and then used.
 
         def _test(replaced_value, initial_value):
             for version_file in self.version_files_without_excluded:


### PR DESCRIPTION
In repex 1.0.0 and earlier, you could define variables within other variables. The implementation was implicit as all variables were iterated until they are all expanded. In repex 1.1.0, this behavior was changed for a more explicit implementation of the variable expansion logic, leaving this not-implemented. This fix this while also raising an error if a variable in a variable fails to expand.